### PR TITLE
support for bright colours

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -86,6 +86,39 @@ pub enum AnsiKeyword {
     /// White background color.
     BgWhite,
 
+    /// Gray foreground color.
+    Gray,
+    /// Gray background color.
+    BgGray,
+    /// Bright red foreground color.
+    BrightRed,
+    /// Bright red background color.
+    BgBrightRed,
+    /// Bright green foreground color.
+    BrightGreen,
+    /// Bright green background color.
+    BgBrightGreen,
+    /// Bright yellow foreground color.
+    BrightYellow,
+    /// Bright yellow background color.
+    BgBrightYellow,
+    /// Bright blue foreground color.
+    BrightBlue,
+    /// Bright blue background color.
+    BgBrightBlue,
+    /// Pink foreground color.
+    BrightMagenta,
+    /// Pink background color.
+    BgBrightMagenta,
+    /// Bright cyan foreground color.
+    BrightCyan,
+    /// Bright cyan background color.
+    BgBrightCyan,
+    /// Bright white foreground color.
+    BrightWhite,
+    /// Bright white background color.
+    BgBrightWhite,
+
     /// Reset/Clear all style.
     Clear,
     /// Reset/Clear all style.
@@ -130,6 +163,22 @@ impl AnsiKeyword {
             AnsiKeyword::BgCyan => "46",
             AnsiKeyword::White => "37",
             AnsiKeyword::BgWhite => "47",
+            AnsiKeyword::Gray => "90",
+            AnsiKeyword::BgGray => "100",
+            AnsiKeyword::BrightRed => "91",
+            AnsiKeyword::BgBrightRed => "101",
+            AnsiKeyword::BrightGreen => "92",
+            AnsiKeyword::BgBrightGreen => "102",
+            AnsiKeyword::BrightYellow => "93",
+            AnsiKeyword::BgBrightYellow => "103",
+            AnsiKeyword::BrightBlue => "94",
+            AnsiKeyword::BgBrightBlue => "104",
+            AnsiKeyword::BrightMagenta => "95",
+            AnsiKeyword::BgBrightMagenta => "105",
+            AnsiKeyword::BrightCyan => "96",
+            AnsiKeyword::BgBrightCyan => "106",
+            AnsiKeyword::BrightWhite => "97",
+            AnsiKeyword::BgBrightWhite => "107",
             AnsiKeyword::Clear | AnsiKeyword::Reset => "0",
             AnsiKeyword::Bold => "1",
             AnsiKeyword::Dimmed => "2",


### PR DESCRIPTION
The names are mostly based on [the Wikipedia table](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors) as of writing.

For anyone having the very common "bold equals bright" setting mentioned in #4, this doesn't really do that much. However you can test the new colour "gray" (bright black) which should be recognised either way.

I ran some output through *ansi2html* which did make a difference, as per this screenshot (should be bright green "foo" and regular green "bar"):

![image](https://github.com/user-attachments/assets/6cee0a91-0b56-48d5-8fe5-57eea6c2dd65)
